### PR TITLE
Minor naming fixes

### DIFF
--- a/generators/app/templates/src/controller/BaseController.ts
+++ b/generators/app/templates/src/controller/BaseController.ts
@@ -71,7 +71,7 @@ export default abstract class BaseController extends Controller {
 	/**
 	 * Convenience event handler for navigating back.
 	 * It there is a history entry we go one step back in the browser history
-	 * If not, it will replace the current entry of the browser history with the master route.
+	 * If not, it will replace the current entry of the browser history with the main route.
 	 */
 	public onNavBack(): void {
 		const sPreviousHash = History.getInstance().getPreviousHash();

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -12,7 +12,7 @@
         "rootDir": "./src",
         "outDir": "./dist",
         "baseUrl": "./",
-        "moduleResolution": "Node",
+        "moduleResolution": "node",
         "typeRoots": [
             "./node_modules/@types",
             "./node_modules/<%= tstypes %>"


### PR DESCRIPTION
According to
https://www.typescriptlang.org/docs/handbook/module-resolution.html#module-resolution-strategies,
"moduleResolution: "Node" has "node" written all-lowercase.

The main route is named "main", not "master".