### PR TITLE
feat: add prompt for git repo initialization

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -112,6 +112,12 @@ module.exports = class extends Generator {
         name: "newdir",
         message: "Would you like to create a new directory for the application?",
         default: true
+      },
+      {
+        type: "confirm",
+        name: "initrepo",
+        message: "Would you like to initialize a local github repository for the application?",
+        default: true
       }
     ];
 
@@ -169,24 +175,26 @@ module.exports = class extends Generator {
   }
 
   end() {
-    this.spawnCommandSync("git", ["init", "--quiet"], {
-      cwd: this.destinationPath()
-    });
-    this.spawnCommandSync("git", ["add", "."], {
-      cwd: this.destinationPath()
-    });
-    this.spawnCommandSync(
-      "git",
-      [
-        "commit",
-        "--quiet",
-        "--allow-empty",
-        "-m",
-        "Initial commit"
-      ],
-      {
+    if (this.config.initrepo) {
+      this.spawnCommandSync("git", ["init", "--quiet"], {
         cwd: this.destinationPath()
-      }
-    );
+      });
+      this.spawnCommandSync("git", ["add", "."], {
+        cwd: this.destinationPath()
+      });
+      this.spawnCommandSync(
+        "git",
+        [
+          "commit",
+          "--quiet",
+          "--allow-empty",
+          "-m",
+          "Initial commit"
+        ],
+        {
+          cwd: this.destinationPath()
+        }
+      );
+    }
   }
 };


### PR DESCRIPTION
This PR is created as a result of the discussion in https://github.com/SAP/generator-easy-ui5/issues/109. A `confirm` option with the name `initrepo` is added to the `prompts` array and in the `end` function git initialization steps are only performed if `this.config.initrepo` is true (the default value).