### PR TITLE
feat: add ui5 middleware code coverage

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -137,6 +137,13 @@ export default class extends Generator {
 				this.config.set("defaultTheme", "sap_fiori_3");
 			}
 
+			// set qunit coverage file
+			if (semver.gte(props.frameworkVersion, "1.113.0")) {
+				this.config.set("qunitCoverageFile", "qunit-coverage-istanbul.js");
+			} else {
+				this.config.set("qunitCoverageFile", "qunit-coverage.js");
+			}
+
 			// more relevant parameters
 			this.config.set("gte11150", semver.gte(props.frameworkVersion, "1.115.0"));
 		});

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -24,6 +24,7 @@
 		"@typescript-eslint/eslint-plugin": "^6.2.0",
 		"@typescript-eslint/parser": "^6.2.0",
 		"@ui5/cli": "^3.3.4",
+		"@ui5/middleware-code-coverage": "^1.1.0",
 		"eslint": "^8.46.0",
 		"karma": "^6.4.2",
 		"karma-chrome-launcher": "^3.2.0",

--- a/generators/app/templates/ui5.yaml
+++ b/generators/app/templates/ui5.yaml
@@ -19,3 +19,5 @@ server:
       afterMiddleware: compression
     - name: ui5-middleware-livereload
       afterMiddleware: compression
+    - name: "@ui5/middleware-code-coverage"
+      afterMiddleware: compression

--- a/generators/app/templates/webapp/test/integration/opaTests.qunit.html
+++ b/generators/app/templates/webapp/test/integration/opaTests.qunit.html
@@ -22,6 +22,7 @@
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
 	</head>
 	<body>
 		<div id="qunit"></div>

--- a/generators/app/templates/webapp/test/unit/unitTests.qunit.html
+++ b/generators/app/templates/webapp/test/unit/unitTests.qunit.html
@@ -19,7 +19,7 @@
 		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
 		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
 		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
-		<script src="../../resources/sap/ui/qunit/qunit-coverage.js"></script>
+		<script src="../../resources/sap/ui/qunit/<%= qunitCoverageFile %>" data-sap-ui-cover-only="<%= appURI %>/" data-sap-ui-cover-never="<%= appURI %>/test/"></script>
 		<script src="../../resources/sap/ui/thirdparty/sinon.js"></script>
 		<script src="../../resources/sap/ui/thirdparty/sinon-qunit.js"></script>
 	</head>


### PR DESCRIPTION
Allows client side code coverage generation for ES6+ code powered by https://github.com/SAP/ui5-tooling-extensions/tree/main/packages/middleware-code-coverage.

Projects generated for UI5 versions before 1.113.0 will stick to old "Blanket.js" based code coverage determination limited to ES5 language specification.

JIRA: CPOUI5FOUNDATION-721
