### PR TITLE
fix: replace deprecated MessagePage with IllustratedMessage (UI5 2.x)

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,7 +138,9 @@ export default class extends Generator {
 			}
 
 			// more relevant parameters
-			this.config.set("gte11150", semver.gte(props.frameworkVersion, "1.115.0"));
+			this.config.set("gte1_98_0", semver.gte(props.frameworkVersion, "1.98.0"));
+			this.config.set("gte1_104_0", semver.gte(props.frameworkVersion, "1.104.0"));
+			this.config.set("gte1_115_0", semver.gte(props.frameworkVersion, "1.115.0"));
 		});
 	}
 

--- a/generators/app/templates/webapp/Component.ts
+++ b/generators/app/templates/webapp/Component.ts
@@ -1,5 +1,5 @@
 import UIComponent from "sap/ui/core/UIComponent";
-import models from "./model/models";<% if (gte11150) { %>
+import models from "./model/models";<% if (gte1_115_0) { %>
 import Device from "sap/ui/Device";<% } else { %>
 import * as Device from "sap/ui/Device"; // for UI5 >= 1.115.0 use: import Device from "sap/ui/Device";<% } %>
 

--- a/generators/app/templates/webapp/model/models.ts
+++ b/generators/app/templates/webapp/model/models.ts
@@ -1,6 +1,6 @@
 import JSONModel from "sap/ui/model/json/JSONModel";
 import BindingMode from "sap/ui/model/BindingMode";
-<% if (gte11150) { %>
+<% if (gte1_115_0) { %>
 import Device from "sap/ui/Device";
 <% } else { %>
 import * as Device from "sap/ui/Device"; // for UI5 >= 1.115.0 use: import Device from "sap/ui/Device";

--- a/generators/app/templates/webapp/view/Main.view.xml
+++ b/generators/app/templates/webapp/view/Main.view.xml
@@ -7,7 +7,26 @@
 	core:require="{
 		formatter: '<%= appURI %>/model/formatter'
 	}">
-
+<% if (gte1_98_0) { %>
+	<Page
+		title="{i18n>appTitle}"
+		id="page">
+		<content>
+			<IllustratedMessage
+				title="{i18n>appTitle}"
+				illustrationType="sapIllus-SuccessHighFive"<% if (gte1_104_0) { %>
+				enableVerticalResponsiveness="true"<% } %>
+				description="{i18n>appDescription}">
+				<additionalContent>
+					<Button
+						id="helloButton"
+						text="{formatter: 'formatter.formatValue', path: 'i18n>btnText'}"
+						press="sayHello" />
+				</additionalContent>
+			</IllustratedMessage>
+		</content>
+	</Page>
+<% } else { %>
 	<MessagePage
 		title="{i18n>appTitle}"
 		text="{i18n>appTitle}"
@@ -21,5 +40,5 @@
 				press="sayHello" />
 		</buttons>
 	</MessagePage>
-
+<% } %>
 </mvc:View>


### PR DESCRIPTION
Stay with MessagePage below 1.98 because IllustratedMessage was only added then.
Also make the version flags a bit easier to read.
This makes the template work with UI5 2.x.