### PR TITLE
fix: Build set manifest.json version from package.json

### DIFF
--- a/generators/app/templates/webapp/manifest.json
+++ b/generators/app/templates/webapp/manifest.json
@@ -8,7 +8,7 @@
 		"title": "{{appTitle}}",
 		"description": "{{appDescription}}",
 		"applicationVersion": {
-			"version": "1.0.0"
+			"version": "${version}"
 		}
 	},
 


### PR DESCRIPTION
The manifest.json version property was hardcoded. Now, it's set from package.json when building the app.