### PR TITLE
fix: forbid uppercase characters for namespace 

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -50,11 +50,11 @@ export default class extends Generator {
 				name: "namespace",
 				message: "Enter your application id (namespace)?",
 				validate: (s) => {
-					if (/^[a-zA-Z0-9][a-zA-Z0-9_.]*$/g.test(s)) {
+					if (/^[a-z0-9][a-z0-9_.]*$/g.test(s)) {
 						return true;
 					}
 
-					return "Please use alpha numeric characters and dots only for the namespace.";
+					return "Please use lowercase alpha numeric characters and dots only for the namespace.";
 				},
 				default: "com.myorg.myapp"
 			},


### PR DESCRIPTION
Forbid uppercase characters for namespace to avoid invalid ```ui5.yaml``` and ```package.json```. Fix for issue #38 

[CoPilot]
This pull request includes a small change to the `generators/app/index.js` file. The change ensures that the namespace validation only allows lowercase alphanumeric characters and dots.

* [`generators/app/index.js`](diffhunk://#diff-fb3c51194730e282793310751066bf26defbbee94fc60924bbde9d954f646e6fL53-R57): Modified the namespace validation regex to only allow lowercase alphanumeric characters and dots, and updated the validation message accordingly.