### PR TITLE
fix: namespace used as package name und project name in ui5.yaml

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -125,8 +125,9 @@ export default class extends Generator {
 			this.config.set("tstypesVersion", props.frameworkVersion);
 
 			// appId + appURI
-			this.config.set("appId", `${props.namespace}`);
-			this.config.set("appURI", `${props.namespace.split(".").join("/")}`);
+			const parts = props.namespace.split(".");
+			this.config.set("appId", parts[parts.length - 1]);
+			this.config.set("appURI", parts.join("/"));
 
 			// CDN domain
 			this.config.set("cdnDomain", fwkCDNDomain[props.framework]);

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "<%= namespace %>",
+	"name": "<%= appId %>",
 	"version": "1.0.0",
 	"description": "UI5 Application: <%= namespace %>",
 	"author": "<%= author %>",

--- a/generators/app/templates/webapp/Component.ts
+++ b/generators/app/templates/webapp/Component.ts
@@ -4,7 +4,7 @@ import Device from "sap/ui/Device";<% } else { %>
 import * as Device from "sap/ui/Device"; // for UI5 >= 1.115.0 use: import Device from "sap/ui/Device";<% } %>
 
 /**
- * @namespace <%= appId %>
+ * @namespace <%= namespace %>
  */
 export default class Component extends UIComponent {
 	public static metadata = {

--- a/generators/app/templates/webapp/controller/App.controller.ts
+++ b/generators/app/templates/webapp/controller/App.controller.ts
@@ -1,7 +1,7 @@
 import BaseController from "./BaseController";
 
 /**
- * @namespace <%= appId %>.controller
+ * @namespace <%= namespace %>.controller
  */
 export default class App extends BaseController {
 	public onInit(): void {

--- a/generators/app/templates/webapp/controller/BaseController.ts
+++ b/generators/app/templates/webapp/controller/BaseController.ts
@@ -8,7 +8,7 @@ import Router from "sap/ui/core/routing/Router";
 import History from "sap/ui/core/routing/History";
 
 /**
- * @namespace <%= appId %>.controller
+ * @namespace <%= namespace %>.controller
  */
 export default abstract class BaseController extends Controller {
 	/**

--- a/generators/app/templates/webapp/controller/Main.controller.ts
+++ b/generators/app/templates/webapp/controller/Main.controller.ts
@@ -2,7 +2,7 @@ import MessageBox from "sap/m/MessageBox";
 import BaseController from "./BaseController";
 
 /**
- * @namespace <%= appId %>.controller
+ * @namespace <%= namespace %>.controller
  */
 export default class Main extends BaseController {
 	public sayHello(): void {

--- a/generators/app/templates/webapp/index-cdn.html
+++ b/generators/app/templates/webapp/index-cdn.html
@@ -13,7 +13,7 @@
 			id="sap-ui-bootstrap"
 			src="https://<%= cdnDomain %>/<%= frameworkVersion %>/resources/sap-ui-core.js"
 			data-sap-ui-resource-roots='{
-				"<%= appId %>": "./"
+				"<%= namespace %>": "./"
 			}'
 			data-sap-ui-theme="<%= defaultTheme %>"
 			data-sap-ui-on-init="module:sap/ui/core/ComponentSupport"
@@ -26,6 +26,6 @@
 	</head>
 
 	<body class="sapUiBody">
-		<div data-sap-ui-component data-name="<%= appId %>"></div>
+		<div data-sap-ui-component data-name="<%= namespace %>"></div>
 	</body>
 </html>

--- a/generators/app/templates/webapp/index.html
+++ b/generators/app/templates/webapp/index.html
@@ -12,7 +12,7 @@
 			id="sap-ui-bootstrap"
 			src="resources/sap-ui-core.js"
 			data-sap-ui-resource-roots='{
-				"<%= appId %>": "./"
+				"<%= namespace %>": "./"
 			}'
 			data-sap-ui-theme="<%= defaultTheme %>"
 			data-sap-ui-on-init="module:sap/ui/core/ComponentSupport"
@@ -25,6 +25,6 @@
 	</head>
 
 	<body class="sapUiBody">
-		<div data-sap-ui-component data-name="<%= appId %>"></div>
+		<div data-sap-ui-component data-name="<%= namespace %>"></div>
 	</body>
 </html>

--- a/generators/app/templates/webapp/manifest.json
+++ b/generators/app/templates/webapp/manifest.json
@@ -24,7 +24,7 @@
 
 	"sap.ui5": {
 		"rootView": {
-			"viewName": "<%= appId %>.view.App",
+			"viewName": "<%= namespace %>.view.App",
 			"type": "XML",
 			"async": true,
 			"id": "app"
@@ -49,7 +49,7 @@
 			"i18n": {
 				"type": "sap.ui.model.resource.ResourceModel",
 				"settings": {
-					"bundleName": "<%= appId %>.i18n.i18n"
+					"bundleName": "<%= namespace %>.i18n.i18n"
 				}
 			}
 		},
@@ -58,7 +58,7 @@
 			"config": {
 				"routerClass": "sap.m.routing.Router",
 				"viewType": "XML",
-				"viewPath": "<%= appId %>.view",
+				"viewPath": "<%= namespace %>.view",
 				"controlId": "app",
 				"controlAggregation": "pages",
 				"async": true

--- a/generators/app/templates/webapp/test/integration/HelloJourney.ts
+++ b/generators/app/templates/webapp/test/integration/HelloJourney.ts
@@ -9,7 +9,7 @@ opaTest("Should open the Hello dialog", function () {
 	// Arrangements
 	onTheMainPage.iStartMyUIComponent({
 		componentConfig: {
-			name: "<%= appId %>"
+			name: "<%= namespace %>"
 		}
 	});
 
@@ -33,7 +33,7 @@ opaTest("Should close the Hello dialog", function () {
 	// Arrangements
 	onTheMainPage.iStartMyUIComponent({
 		componentConfig: {
-			name: "<%= appId %>"
+			name: "<%= namespace %>"
 		}
 	});
 

--- a/generators/app/templates/webapp/test/integration/opaTests.qunit.html
+++ b/generators/app/templates/webapp/test/integration/opaTests.qunit.html
@@ -11,7 +11,7 @@
 			src="../../resources/sap-ui-core.js"
 			data-sap-ui-theme="<%= defaultTheme %>"
 			data-sap-ui-resource-roots='{
-				"<%= appId %>": "../../",
+				"<%= namespace %>": "../../",
 				"integration": "."
 			}'
 			data-sap-ui-animation="false"

--- a/generators/app/templates/webapp/test/integration/pages/MainPage.ts
+++ b/generators/app/templates/webapp/test/integration/pages/MainPage.ts
@@ -1,7 +1,7 @@
 import Opa5 from "sap/ui/test/Opa5";
 import Press from "sap/ui/test/actions/Press";
 
-const viewName = "<%= appId %>.view.Main";
+const viewName = "<%= namespace %>.view.Main";
 
 export default class MainPage extends Opa5 {
 	// Actions

--- a/generators/app/templates/webapp/test/unit/unitTests.qunit.html
+++ b/generators/app/templates/webapp/test/unit/unitTests.qunit.html
@@ -10,7 +10,7 @@
 			id="sap-ui-bootstrap"
 			src="../../resources/sap-ui-core.js"
 			data-sap-ui-resource-roots='{
-				"<%= appId %>": "../../",
+				"<%= namespace %>": "../../",
 				"unit": "."
 			}'
 			data-sap-ui-compat-version="edge"

--- a/generators/app/templates/webapp/view/App.view.xml
+++ b/generators/app/templates/webapp/view/App.view.xml
@@ -1,5 +1,5 @@
 <mvc:View
-	controllerName="<%= appId %>.controller.App"
+	controllerName="<%= namespace %>.controller.App"
 	displayBlock="true"
 	xmlns="sap.m"
 	xmlns:mvc="sap.ui.core.mvc">

--- a/generators/app/templates/webapp/view/Main.view.xml
+++ b/generators/app/templates/webapp/view/Main.view.xml
@@ -1,5 +1,5 @@
 <mvc:View
-	controllerName="<%= appId %>.controller.Main"
+	controllerName="<%= namespace %>.controller.Main"
 	displayBlock="true"
 	xmlns="sap.m"
 	xmlns:mvc="sap.ui.core.mvc"


### PR DESCRIPTION
As of now the template variables ```appId``` and ```namespace``` hold the provided namespace value. I think it was intended that the appId is just the last part of the namespace and used for example as name in ```package.json``` and project name in ```ui5.yaml```. As of now the whole namespace is used in these files which is rather uncommon IMO. This PR puts the namespace wherever sensible and uses the appId as project and package name.

 