### PR TITLE
feat: use sinon 4 instead of 1 in test config

### DIFF
--- a/generators/app/templates/webapp/test/testsuite.qunit.ts
+++ b/generators/app/templates/webapp/test/testsuite.qunit.ts
@@ -6,7 +6,7 @@ export default {
 			version: 2
 		},
 		sinon: {
-			version: 1
+			version: 4
 		},
 		ui5: {
 			language: "EN",


### PR DESCRIPTION
This makes no difference in the actually implemented minimal tests, but
is a better starting point for apps.
This only affects the new versions from 1.124, which are using the UI5
Test Starter.

Fixes https://github.com/ui5-community/generator-ui5-ts-app/issues/34