### PR TITLE
feat: declare generation arguments to enable silent usage

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,6 +25,43 @@ export default class extends Generator {
 			// disable the Yeoman 5 package-manager logic (auto install)!
 			customInstallTask: "disabled"
 		});
+
+		// declare the arguments and options of the generator, so they can be shown by --help
+		this.argument("appNamespace", { // "appNamespace" is used here to avoid a conflict with the "namespace" property, which is natively in this.options, where these arguments also end up
+			type: String,
+			required: false,
+			description: "The namespace for the application, e.g. com.myorg.myapp"
+		});
+
+		this.argument("framework", {
+			type: String,
+			required: false,
+			description: "The framework to use, i.e. OpenUI5 or SAPUI5"
+		});
+
+		this.argument("frameworkVersion", {
+			type: String,
+			required: false,
+			description: "The framework version to use, e.g. 1.136.0"
+		});
+
+		this.argument("author", {
+			type: String,
+			required: false,
+			description: "The author of the application, e.g. John Doe"
+		});
+
+		this.argument("newdir", {
+			type: Boolean,
+			required: false,
+			description: "Whether a new directory should be created for the application"
+		});
+
+		this.argument("initrepo", {
+			type: Boolean,
+			required: false,
+			description: "Whether to initialize a local git repository for the application"
+		});
 	}
 
 	prompting() {
@@ -48,8 +85,45 @@ export default class extends Generator {
 			return `@${framework.toLowerCase()}/${typesName}`;
 		};
 
-		const prompts = [
-			{
+		// validate any arguments given via CLI
+		if (!/^[a-z0-9][a-z0-9_.]*$/g.test(this.options.appNamespace)) {
+			this.log(chalk.red("The provided namespace is not valid! Please use lowercase alpha numeric characters, underscores and dots only."));
+			delete this.options.appNamespace;
+		}
+
+		if (this.options.framework && !["OpenUI5", "SAPUI5"].includes(this.options.framework)) {
+			this.log(chalk.red("The provided framework is not valid! Please use either OpenUI5 or SAPUI5."));
+			delete this.options.framework;
+		}
+
+		if (this.options.frameworkVersion && !semver.valid(this.options.frameworkVersion)) {
+			this.log(chalk.red("The provided framework version is not valid! Please use a valid semantic version, e.g. 1.136.0."));
+			delete this.options.frameworkVersion;
+		} else if (this.options.frameworkVersion && this.options.framework && semver.lt(this.options.frameworkVersion, minFwkVersion[this.options.framework])) {
+			this.log(chalk.red(`The provided framework version ${this.options.frameworkVersion} is not valid! The minimum version for ${this.options.framework} is ${minFwkVersion[this.options.framework]}.`));
+			delete this.options.frameworkVersion;
+		}
+
+		if (this.options.newdir !== undefined) { // it's coming as string because it is an argument, not an option, so we can differentiate between "undefined" and "false" value
+			if (this.options.newdir === "false") {
+				this.options.newdir = false;
+			} else if (this.options.newdir === "true") {
+				this.options.newdir = true;
+			}
+		}
+
+		if (this.options.initrepo !== undefined) { // same as above
+			if (this.options.initrepo === "false") {
+				this.options.initrepo = false;
+			} else if (this.options.initrepo === "true") {
+				this.options.initrepo = true;
+			}
+		}
+
+		// prepare the needed prompts
+		const prompts = [];
+		if (!this.options.appNamespace) { // only prompt the user when not provided already
+			prompts.push({
 				type: "input",
 				name: "namespace",
 				message: "Enter your application id (namespace)?",
@@ -58,27 +132,33 @@ export default class extends Generator {
 						return true;
 					}
 
-					return "Please use lowercase alpha numeric characters and dots only for the namespace.";
+					return "Please use lowercase alpha numeric characters, underscores and dots only for the namespace.";
 				},
 				default: "com.myorg.myapp"
-			},
-			{
+			});
+		}
+
+		if (!this.options.framework) {
+			prompts.push({
 				type: "list",
 				name: "framework",
 				message: "Which framework do you want to use?",
 				choices: ["OpenUI5", "SAPUI5"],
 				default: "OpenUI5"
-			},
-			{
+			});
+		}
+		
+		if (!this.options.frameworkVersion) {
+			prompts.push({
 				when: (response) => {
-					this._minFwkVersion = minFwkVersion[response.framework];
+					this._minFwkVersion = minFwkVersion[response.framework || this.options.framework];
 					return true;
 				},
 				type: "input", // HINT: we could also use the version info from OpenUI5/SAPUI5 to provide a selection!
 				name: "frameworkVersion",
 				message: "Which framework version do you want to use?",
 				default: async (answers) => {
-					const npmPackage = getTypePackageFor(answers.framework);
+					const npmPackage = getTypePackageFor(answers.framework || this.options.framework);
 					try {
 						return (
 							await packageJson(npmPackage, {
@@ -87,34 +167,49 @@ export default class extends Generator {
 						).version;
 					} catch (ex) {
 						chalk.red("Failed to lookup latest version for ${npmPackage}! Fallback to min version...");
-						return minFwkVersion[answers.framework];
+						return minFwkVersion[answers.framework || this.options.framework];
 					}
 				},
 				validate: (v) => {
-					return (v && semver.valid(v) && semver.gte(v, this._minFwkVersion)) || chalk.red(`Framework requires the min version ${this._minFwkVersion} due to the availability of the ts-types!`);
+					return (v && semver.valid(v) && semver.gte(v, this._minFwkVersion)) || chalk.red(`Framework requires the min version ${this._minFwkVersion} due to the availability of the type definitions!`);
 				}
-			},
-			{
+			});
+		}
+
+		if (!this.options.author) {
+			prompts.push({
 				type: "input",
 				name: "author",
 				message: "Who is the author of the application?",
 				default: this.user.git.name()
-			},
-			{
+			});
+		}
+
+		if (this.options.newdir === undefined) {
+			prompts.push({
 				type: "confirm",
 				name: "newdir",
 				message: "Would you like to create a new directory for the application?",
 				default: true
-			},
-			{
+			});
+		}
+
+		if (this.options.initrepo === undefined) {
+			prompts.push({
 				type: "confirm",
 				name: "initrepo",
 				message: "Would you like to initialize a local git repository for the application?",
 				default: true
-			}
-		];
+			});
+		}
 
 		return this.prompt(prompts).then((props) => {
+			// merge pre-filled arguments with prompt answers
+			Object.values(this._arguments).map((v) => v.name).forEach((key) => {
+				props[key] = props[key] || this.options[key];
+			});
+			props.namespace = props.namespace || props.appNamespace; // use "namespace" from here ("appNamespace" was used in the CLI to prevent a conflict with native this.options content)
+
 			// use the namespace and the application name as new subdirectory
 			if (props.newdir) {
 				this.destinationRoot(this.destinationPath(`${props.namespace}`));


### PR DESCRIPTION
Declaring the arguments makes sure yo ts-app --help does display and explain the possible arguments. It also enables the generator to run without any user interaction, e.g. from within a code generation tool.

The two boolean ones (newdir, initrepo) have been modeled as "arguments", not as "options" (=flags) because as options the difference between wanting them to be "false" and not wanting to set them as commandline arguments could not be recognized.