### PR TITLE
docs: Add TS type definitions for Test Starter Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License Status][license-image]][license-url]
 
-[Yeoman](https://yeoman.io/) generator kickstarting the development of UI5 applications using TypeScript. The generator incorporates the latest best-practices, is using the [UI5 Tooling](https://sap.github.io/ui5-tooling/) and the UI5 Tooling extensions provided by the [UI5 community](https://github.com/ui5-community/ui5-ecosystem-showcase/). It is maintained by the UI5 community and [OpenUI5](https://openui5.org)/[SAPUI5](https://ui5.sap.com) developers. This generator was build as a plug-in for the community project [Easy-UI5](https://github.com/SAP/generator-easy-ui5/) by [SAP](https://github.com/SAP/).
+[Yeoman](https://yeoman.io/) generator kickstarting the development of UI5 applications using TypeScript. The generator incorporates the latest best-practices, is using the [UI5 CLI](https://ui5.github.io/cli/) and the UI5 CLI extensions provided by the [UI5 community](https://github.com/ui5-community/ui5-ecosystem-showcase/). It is maintained by the UI5 community and [OpenUI5](https://openui5.org)/[SAPUI5](https://ui5.sap.com) developers. This generator was build as a plug-in for the community project [Easy-UI5](https://github.com/SAP/generator-easy-ui5/) by [SAP](https://github.com/SAP/).
 
 ## Usage with Easy-UI5
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -242,6 +242,7 @@ export default class extends Generator {
 			this.config.set("gte1_104_0", semver.gte(props.frameworkVersion, "1.104.0"));
 			this.config.set("gte1_115_0", semver.gte(props.frameworkVersion, "1.115.0"));
 			this.config.set("gte1_120_0", semver.gte(props.frameworkVersion, "1.120.0"));
+			this.config.set("gte1_142_0", semver.gte(props.frameworkVersion, "1.142.0"));
 			this.config.set("lt1_124_0", semver.lt(props.frameworkVersion, "1.124.0"));
 		});
 	}

--- a/generators/app/templates/README.md
+++ b/generators/app/templates/README.md
@@ -54,7 +54,7 @@ The result is placed into the `dist` folder. To start the generated package, jus
 npm run start:dist
 ```
 
-Note that `index.html` still loads the UI5 framework from the relative URL `resources/...`, which does not physically exist, but is only provided dynamically by the UI5 tooling. So for an actual deployment you should change this URL to either [the CDN](https://sdk.openui5.org/#/topic/2d3eb2f322ea4a82983c1c62a33ec4ae) or your local deployment of UI5.
+Note that `index.html` still loads the UI5 framework from the relative URL `resources/...`, which does not physically exist, but is only provided dynamically by the UI5 CLI. So for an actual deployment you should change this URL to either [the CDN](https://sdk.openui5.org/#/topic/2d3eb2f322ea4a82983c1c62a33ec4ae) or your local deployment of UI5.
 
 (When using yarn, do `yarn build` and `yarn start:dist` instead.)
 

--- a/generators/app/templates/webapp/test/testsuite.qunit.ts
+++ b/generators/app/templates/webapp/test/testsuite.qunit.ts
@@ -1,3 +1,6 @@
+<% if (gte1_142_0) { -%>
+import type {SuiteConfiguration} from "sap/ui/test/starter/config";
+<% } -%>
 export default {
 	name: "QUnit test suite for the UI5 Application: <%= namespace %>",
 	defaults: {
@@ -13,8 +16,8 @@ export default {
 			theme: "<%= defaultTheme %>"
 		},
 		coverage: {
-			only: "<%= appURI %>/",
-			never: "test-resources/<%= appURI %>/"
+			only: ["<%= appURI %>/"],
+			never: ["test-resources/<%= appURI %>/"]
 		},
 		loader: {
 			paths: {
@@ -30,4 +33,4 @@ export default {
 			title: "Integration tests for <%= namespace %>"
 		}
 	}
-};
+}<% if (gte1_142_0) { -%> satisfies SuiteConfiguration<% }  -%>;


### PR DESCRIPTION
Adds type definitions to the generator template (only applies them if UI5 version >= 1.142.0).

JIRA: CPOUI5FOUNDATION-1123